### PR TITLE
Removes a depositor from settings for new users.

### DIFF
--- a/packages/frontend/src/components/UserToolbar.tsx
+++ b/packages/frontend/src/components/UserToolbar.tsx
@@ -68,8 +68,7 @@ const UserToolbar = ({
             user: {
               username: '',
               role: 'User',
-              depositors:
-                'Centrum för Näringslivshistoria;Föreningen Stockholms Företagsminnen',
+              depositors: 'Föreningen Stockholms Företagsminnen',
             },
             allGroups,
           }}


### PR DESCRIPTION
Removes "Centrum för Näringslivshistoria" from default depositors when creating new users.