### PR TITLE
Enhance filtered options logic with current items context

### DIFF
--- a/packages/frontend/src/common/types.ts
+++ b/packages/frontend/src/common/types.ts
@@ -187,8 +187,6 @@ interface UserToolbarProps {
 interface FilteredOptionsProps {
   fieldName: string
   fieldNames: string[]
-  filterFieldName: string
-  filterValue: string | undefined
   selectedItems: string[]
   currentItems: Record<string, string>
 }

--- a/packages/frontend/src/common/types.ts
+++ b/packages/frontend/src/common/types.ts
@@ -190,6 +190,7 @@ interface FilteredOptionsProps {
   filterFieldName: string
   filterValue: string | undefined
   selectedItems: string[]
+  currentItems: Record<string, string>
 }
 
 interface FormSection {

--- a/packages/frontend/src/pages/Users/components/ItemSection.tsx
+++ b/packages/frontend/src/pages/Users/components/ItemSection.tsx
@@ -29,6 +29,7 @@ export const ItemSection = ({
     filterFieldName: 'depositor',
     filterValue: sectionFormState.depositor,
     selectedItems,
+    currentItems: sectionFormState,
   })
 
   const rawSeriesOptions = useFilteredOptions({
@@ -37,6 +38,7 @@ export const ItemSection = ({
     filterFieldName: 'archiveInitiator',
     filterValue: sectionFormState.archiveInitiator,
     selectedItems,
+    currentItems: sectionFormState,
   })
 
   const rawVolumeOptions = useFilteredOptions({
@@ -45,6 +47,7 @@ export const ItemSection = ({
     filterFieldName: 'seriesName',
     filterValue: sectionFormState.seriesName,
     selectedItems,
+    currentItems: sectionFormState,
   })
 
   const seriesOptions = section.fieldNames.includes('seriesName')

--- a/packages/frontend/src/pages/Users/components/ItemSection.tsx
+++ b/packages/frontend/src/pages/Users/components/ItemSection.tsx
@@ -26,8 +26,6 @@ export const ItemSection = ({
   const archiveInitiatorOptions = useFilteredOptions({
     fieldName: 'archiveInitiator',
     fieldNames: section.fieldNames,
-    filterFieldName: 'depositor',
-    filterValue: sectionFormState.depositor,
     selectedItems,
     currentItems: sectionFormState,
   })
@@ -35,8 +33,6 @@ export const ItemSection = ({
   const rawSeriesOptions = useFilteredOptions({
     fieldName: 'seriesName',
     fieldNames: section.fieldNames,
-    filterFieldName: 'archiveInitiator',
-    filterValue: sectionFormState.archiveInitiator,
     selectedItems,
     currentItems: sectionFormState,
   })
@@ -44,8 +40,6 @@ export const ItemSection = ({
   const rawVolumeOptions = useFilteredOptions({
     fieldName: 'volume',
     fieldNames: section.fieldNames,
-    filterFieldName: 'seriesName',
-    filterValue: sectionFormState.seriesName,
     selectedItems,
     currentItems: sectionFormState,
   })

--- a/packages/frontend/src/pages/Users/hooks/useFilteredOptions.ts
+++ b/packages/frontend/src/pages/Users/hooks/useFilteredOptions.ts
@@ -7,24 +7,38 @@ export const useFilteredOptions = ({
   filterFieldName,
   filterValue,
   selectedItems,
+  currentItems,
 }: FilteredOptionsProps) => {
   const levelIndex = fieldNames.indexOf(fieldName)
+
+  const prefixChainArray = fieldNames
+    .slice(0, levelIndex)
+    .map((pField) => currentItems[pField])
+    .filter(Boolean)
+
+  const prefixChain = prefixChainArray.join('>')
 
   const options = useFieldOptions(
     fieldName,
     filterValue ? `${filterFieldName}::${filterValue}` : undefined
   )
 
-  const parentLevelItems = selectedItems.filter(
-    (item) => item.split('>')[levelIndex - 1] === filterValue
-  )
+  const sameLevelSelectedItems = selectedItems.filter((sel) => {
+    const parts = sel.split('>')
+    if (parts.length !== levelIndex + 1) {
+      return false
+    }
+    const itemPrefix = parts.slice(0, levelIndex).join('>')
+    return itemPrefix === prefixChain
+  })
 
-  const filteredItems = parentLevelItems.map(
-    (item) => item.split('>')[levelIndex]
-  )
+  const selectedValuesForThisLevel = sameLevelSelectedItems.map((sel) => {
+    const parts = sel.split('>')
+    return parts[levelIndex]
+  })
 
   const filteredOptions = options.filter(
-    (option) => !filteredItems.includes(option)
+    (option) => !selectedValuesForThisLevel.includes(option)
   )
 
   return filteredOptions

--- a/packages/frontend/src/pages/Users/hooks/useFilteredOptions.ts
+++ b/packages/frontend/src/pages/Users/hooks/useFilteredOptions.ts
@@ -4,8 +4,6 @@ import { FilteredOptionsProps } from '../../../common/types'
 export const useFilteredOptions = ({
   fieldName,
   fieldNames,
-  filterFieldName,
-  filterValue,
   selectedItems,
   currentItems,
 }: FilteredOptionsProps) => {
@@ -18,9 +16,15 @@ export const useFilteredOptions = ({
 
   const prefixChain = prefixChainArray.join('>')
 
+  const filterString = Object.entries(currentItems)
+    .slice(0, -1)
+    .filter(([_, value]) => value !== '')
+    .map(([key, value]) => `${key}::${value}`)
+    .join('||')
+
   const options = useFieldOptions(
     fieldName,
-    filterValue ? `${filterFieldName}::${filterValue}` : undefined
+    filterString ? filterString : undefined
   )
 
   const sameLevelSelectedItems = selectedItems.filter((sel) => {


### PR DESCRIPTION
Makes the depositor picker better and solves the issue where volumes from other series with same name could not be added.

- Updated `FilteredOptionsProps` to include `currentItems` for more precise filtering
- Modified `useFilteredOptions` hook to consider parent-level context when filtering options
- Improved option filtering in `ItemSection` to respect hierarchical relationships