### PR TITLE
Feat/194 visa bara 2 rader med deponenter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "digital-reading-room-backoffice",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Backoffice for Digital Reading Room"
 }

--- a/packages/frontend/src/components/DepositorChip.tsx
+++ b/packages/frontend/src/components/DepositorChip.tsx
@@ -1,0 +1,52 @@
+import { Chip, Tooltip } from '@mui/material'
+
+const DepositorChip = ({
+  depositor,
+  truncate = false,
+  showTooltip = true,
+}: {
+  depositor: string
+  truncate?: boolean
+  showTooltip?: boolean
+}) => {
+  const chip = (
+    <Chip
+      label={depositor}
+      variant="outlined"
+      size="small"
+      sx={
+        truncate
+          ? {
+              maxWidth: 150,
+              '.MuiChip-label': {
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              },
+            }
+          : {
+              maxWidth: 'none',
+              height: 'auto',
+              '& .MuiChip-label': {
+                overflow: 'visible',
+                whiteSpace: 'normal',
+                lineHeight: 1.4,
+                py: 0.5,
+                display: 'block',
+                wordBreak: 'break-word',
+              },
+            }
+      }
+    />
+  )
+
+  return showTooltip && truncate ? (
+    <Tooltip title={depositor} arrow>
+      {chip}
+    </Tooltip>
+  ) : (
+    chip
+  )
+}
+
+export default DepositorChip

--- a/packages/frontend/src/components/DepositorTooltip.tsx
+++ b/packages/frontend/src/components/DepositorTooltip.tsx
@@ -1,0 +1,52 @@
+import { Box, useTheme } from '@mui/material'
+import DepositorChip from './DepositorChip'
+
+const DepositorTooltip = ({ depositors }: { depositors: string[] }) => {
+  const theme = useTheme()
+
+  return (
+    <Box
+      sx={{
+        maxWidth: 450,
+        p: 1.5,
+        bgcolor: 'background.paper',
+        borderRadius: 1,
+        boxShadow: 1,
+      }}
+    >
+      <Box
+        sx={{
+          mb: 1.5,
+          fontWeight: 'medium',
+          color: 'text.primary',
+          borderBottom: 1,
+          borderColor: 'divider',
+          pb: 0.5,
+        }}
+      >
+        Alla deponenter
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 0.75,
+          maxHeight: '260px',
+          overflow: 'auto',
+          pr: 0.5,
+        }}
+      >
+        {depositors.map((dep) => (
+          <DepositorChip
+            key={dep}
+            depositor={dep}
+            truncate={false}
+            showTooltip={false}
+          />
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+export default DepositorTooltip

--- a/packages/frontend/src/components/DepositorTooltip.tsx
+++ b/packages/frontend/src/components/DepositorTooltip.tsx
@@ -1,9 +1,8 @@
-import { Box, useTheme } from '@mui/material'
+import { Box } from '@mui/material'
+
 import DepositorChip from './DepositorChip'
 
 const DepositorTooltip = ({ depositors }: { depositors: string[] }) => {
-  const theme = useTheme()
-
   return (
     <Box
       sx={{


### PR DESCRIPTION
Ändrar tabellen över användare så att man maximalt visar 2 rader av deponenter.

Ändrar layouten för att tydligare visa det som är relevant.